### PR TITLE
fix stream implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -262,7 +262,7 @@ impl Stream for EventSource {
                     Poll::Ready(Ok(response)) if response.status() == 204 => Poll::Ready(None),
                     Poll::Ready(Ok(response)) => {
                         self.start_receiving(response);
-                        Poll::Pending
+                        self.poll_next(cx)
                     }
                     Poll::Ready(Err(error)) => {
                         self.start_retry();


### PR DESCRIPTION
Hi, thanks for this library!

The attached patch makes it work for me (on top of the `next` branch). Without this change, it hangs after the Connecting state, I guess because `Poll::Pending` is returned without any active waker. With this change, it reenters the state loop right away in that case and moves the state machine forward as intended.