### PR TITLE
Make Eventsource impl Send

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@ impl fmt::Display for Error {
 impl std::error::Error for Error {}
 
 /// Wrapper for a dynamic Future type that adds an opaque Debug implementation.
-struct DynDebugFuture<T>(Pin<Box<dyn Future<Output = T>>>);
+struct DynDebugFuture<T>(Pin<Box<dyn Future<Output = T> + Send>>);
 impl<T> Future for DynDebugFuture<T> {
     type Output = T;
 


### PR DESCRIPTION
Hyper crate has a similar concept of a `Responsefuture`. (_https://docs.rs/hyper/0.14.8/src/hyper/client/client.rs.html#44-46_). Simply adding a `Send` bound makes the `Eventstream` `Send`, which makes it possible to run the sse-client on other threads.